### PR TITLE
🐛 Fix: AI epics now contain all tasks

### DIFF
--- a/frontend/src/AI/schemas.ts
+++ b/frontend/src/AI/schemas.ts
@@ -50,7 +50,7 @@ export type Message = {
 };
 
 export interface TaskStore {
-  createTask: (title: string, description: string) => void;
-  createEpic: (title: string, description: string) => void;
+  createTask: (title: string, description: string) => string;
+  createEpic: (title: string, description: string) => string;
   assignTaskToEpic: (taskId: string, epicId: string) => void;
 }

--- a/frontend/src/AI/service.ts
+++ b/frontend/src/AI/service.ts
@@ -67,11 +67,17 @@ export const handleAIResponse = async (
     tasks?: Array<{ title: string; description: string }>;
   };
 
-  taskStore.createEpic(epic.title, epic.description);
+  console.log("🏗️ Creating epic:", epic);
+  const epicId = taskStore.createEpic(epic.title, epic.description);
+  console.log("📝 Created epic with ID:", epicId);
 
   if (tasks && tasks.length > 0) {
+    console.log("📎 Attempting to create and assign tasks:", tasks);
     tasks.forEach((task) => {
-      taskStore.createTask(task.title, task.description);
+      console.log("📌 Creating task:", task);
+      const taskId = taskStore.createTask(task.title, task.description);
+      console.log("🔗 Assigning task", taskId, "to epic", epicId);
+      taskStore.assignTaskToEpic(taskId, epicId);
     });
   }
 

--- a/frontend/src/store/taskStore.ts
+++ b/frontend/src/store/taskStore.ts
@@ -30,7 +30,7 @@ interface TaskState {
   epics: Epic[];
 
   // Task Operations
-  createTask: (title: string, description: string) => void;
+  createTask: (title: string, description: string) => string;
   updateTask: (
     id: string,
     updates: Partial<Omit<Task, "id" | "createdAt" | "updatedAt">>
@@ -39,7 +39,7 @@ interface TaskState {
   moveTask: (id: string, status: TaskStatus) => void;
 
   // Epic Operations
-  createEpic: (title: string, description: string) => void;
+  createEpic: (title: string, description: string) => string;
   updateEpic: (
     id: string,
     updates: Partial<Omit<Epic, "id" | "createdAt" | "updatedAt">>
@@ -65,12 +65,13 @@ export const useTaskStore = create<TaskState>()(
       epics: [],
 
       // Task Operations
-      createTask: (title, description) =>
+      createTask: (title, description) => {
+        const id = crypto.randomUUID();
         set((state) => ({
           tasks: [
             ...state.tasks,
             {
-              id: crypto.randomUUID(),
+              id,
               title,
               description,
               status: "pending" as TaskStatus,
@@ -78,7 +79,9 @@ export const useTaskStore = create<TaskState>()(
               updatedAt: Date.now(),
             },
           ],
-        })),
+        }));
+        return id;
+      },
 
       updateTask: (id, updates) =>
         set((state) => ({
@@ -102,12 +105,13 @@ export const useTaskStore = create<TaskState>()(
         })),
 
       // Epic Operations
-      createEpic: (title, description) =>
+      createEpic: (title, description) => {
+        const id = crypto.randomUUID();
         set((state) => ({
           epics: [
             ...state.epics,
             {
-              id: crypto.randomUUID(),
+              id,
               title,
               description,
               status: "active" as EpicStatus,
@@ -115,7 +119,9 @@ export const useTaskStore = create<TaskState>()(
               updatedAt: Date.now(),
             },
           ],
-        })),
+        }));
+        return id;
+      },
 
       updateEpic: (id, updates) =>
         set((state) => ({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `createTask` and `createEpic` now return IDs, enabling task-epic assignment in `handleAIResponse`, with added logging for traceability.
> 
>   - **Behavior**:
>     - `createTask` and `createEpic` now return the ID of the created task/epic in `schemas.ts`, `service.ts`, and `taskStore.ts`.
>     - `handleAIResponse` in `service.ts` updated to assign tasks to epics using returned IDs.
>   - **Logging**:
>     - Added logging in `handleAIResponse` to trace epic and task creation and assignment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fractal-bootcamp%2Fisaac.global-todos&utm_source=github&utm_medium=referral)<sup> for 04b3df5becd1b804d463a00f29f1c19f67d9f1c2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->